### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/kastacho-Garage/23298d33-24f5-4421-b679-582f2bad3b9d/c5e10be5-4d83-4f9d-8fa7-56dc39723fbf/_apis/work/boardbadge/3d1fa0d0-eb20-4618-96ae-fdaece5fec7f)](https://dev.azure.com/kastacho-Garage/23298d33-24f5-4421-b679-582f2bad3b9d/_boards/board/t/c5e10be5-4d83-4f9d-8fa7-56dc39723fbf/Microsoft.RequirementCategory)
 # Introduction
 
 MyShuttle is a sample Java/JEE application that provides booking system, admin portal and a control system for the drivers. The application uses entirely open source software including Linux, Java, Apache, and MySQL which creates a web front end, an order service, and an integration service.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#823](https://dev.azure.com/kastacho-Garage/23298d33-24f5-4421-b679-582f2bad3b9d/_workitems/edit/823). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.